### PR TITLE
Remove deprecated architecture references from install.sh

### DIFF
--- a/tailscale/files/install.sh
+++ b/tailscale/files/install.sh
@@ -7,17 +7,11 @@ BUILD_ARCH="$1"
 TAILSCALE_VERSION="${2#v}"
 
 case "$BUILD_ARCH" in
-  "armhf" | "armv7")
-    TAILSCALE_ARCH="arm"
-    ;;
   "aarch64")
     TAILSCALE_ARCH="arm64"
     ;;
   "amd64")
     TAILSCALE_ARCH="amd64"
-    ;;
-  "i386")
-    TAILSCALE_ARCH="386"
     ;;
 esac
 


### PR DESCRIPTION
Removes the case statements for armhf, armv7, and i386 architectures from the installation script, as these architectures are no longer supported after the migration to hassio-addons base images v19.0.0.

Only aarch64 and amd64 architectures remain supported.