### PR TITLE
Add GitHub workflow for automated container builds and publishing

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -1,0 +1,119 @@
+name: Builder
+
+env:
+  BUILD_ARGS: "--test"
+  MONITORED_FILES: "build.yaml config.yaml Dockerfile files"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  init:
+    runs-on: ubuntu-24.04
+    name: Initialize builds
+    outputs:
+      changed_addons: ${{ steps.changed_addons.outputs.addons }}
+      changed: ${{ steps.changed_addons.outputs.changed }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v6
+
+      - name: Get changed files
+        id: changed_files
+        uses: masesgroup/retrieve-changed-files@v3
+
+      - name: Find add-on directories
+        id: addons
+        uses: home-assistant/actions/helpers/find-addons@master
+
+      - name: Get changed add-ons
+        id: changed_addons
+        run: |
+          declare -a changed_addons
+          for addon in ${{ steps.addons.outputs.addons }}; do
+            if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
+              for file in ${{ env.MONITORED_FILES }}; do
+                  if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then
+                    if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
+                      changed_addons+=("\"${addon}\",");
+                    fi
+                  fi
+              done
+            fi
+          done
+
+          changed=$(echo ${changed_addons[@]} | rev | cut -c 2- | rev)
+
+          if [[ -n ${changed} ]]; then
+            echo "Changed add-ons: $changed";
+            echo "changed=true" >> $GITHUB_OUTPUT;
+            echo "addons=[$changed]" >> $GITHUB_OUTPUT;
+          else
+            echo "No add-on had any monitored files changed (${{ env.MONITORED_FILES }})";
+          fi
+
+  build:
+    needs: init
+    runs-on: ubuntu-24.04
+    if: needs.init.outputs.changed == 'true'
+    name: Build ${{ matrix.arch }} ${{ matrix.addon }} add-on
+    strategy:
+      matrix:
+        addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
+        arch: ["aarch64", "amd64"]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Get information
+        id: info
+        uses: home-assistant/actions/helpers/info@master
+        with:
+          path: "./${{ matrix.addon }}"
+
+      - name: Check if add-on should be built
+        id: check
+        run: |
+          if [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
+            echo "build_arch=true" >> $GITHUB_OUTPUT;
+            echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
+            if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
+                echo "BUILD_ARGS=" >> $GITHUB_ENV;
+            fi
+          else
+            echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
+            echo "build_arch=false" >> $GITHUB_OUTPUT;
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.build_arch == 'true' && env.BUILD_ARGS != '--test'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: env.BUILD_ARGS != '--test'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build ${{ matrix.addon }} add-on
+        if: steps.check.outputs.build_arch == 'true'
+        uses: home-assistant/builder@2025.09.0
+        with:
+          args: |
+            ${{ env.BUILD_ARGS }} \
+            --${{ matrix.arch }} \
+            --target /data/${{ matrix.addon }} \
+            --image "${{ steps.check.outputs.image }}" \
+            --docker-hub "ghcr.io/${{ github.repository_owner }}" \
+            --addon

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -6,6 +6,7 @@ url: "https://github.com/iangelov/home-assistant-addons/tree/main/tailscale"
 arch:
   - aarch64
   - amd64
+image: "ghcr.io/iangelov/addon-tailscale-{arch}"
 startup: services
 boot: auto
 host_network: true


### PR DESCRIPTION
## Summary

This PR adds automated container image building and publishing to the repository using GitHub Actions.

**Changes:**
- Added `.github/workflows/builder.yaml` - GitHub Actions workflow for building multi-architecture container images
- Updated `tailscale/config.yaml` - Added `image` field to reference pre-built containers from GitHub Container Registry

**Key Features:**
- Matrix strategy for parallel builds (aarch64 and amd64)
- Smart change detection to only build modified add-ons
- Test builds on PRs (no publishing), automatic publishing on pushes to main
- Uses latest GitHub Actions versions (checkout@v6, docker actions@v3)
- Runs on ubuntu-24.04 runners for consistent environment
- Image naming: `addon-tailscale-{arch}`

**Technical Implementation:**
- Publishes to GitHub Container Registry: `ghcr.io/iangelov/addon-tailscale-{arch}`
- Skips Docker Buildx in test mode to avoid docker-container driver limitations
- No additional secrets required (uses automatic `GITHUB_TOKEN`)
- Conditional publishing based on event type (PR vs push to main)

**Benefits:**
- Faster user installations (pre-built images vs local compilation)
- Reduced installation failures (no build-time errors on user devices)
- Less wear on user hardware
- Follows official Home Assistant add-on best practices

## Test Plan

- [x] Verify workflow syntax is valid
- [x] Wait for test build to complete on this PR
- [ ] Check Actions tab for successful build completion
- [ ] After merge, verify images are published to ghcr.io
- [ ] Confirm both aarch64 and amd64 images are available

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
