### PR TITLE
Fix: Remove Docker Buildx to resolve production build failures

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -94,10 +94,6 @@ jobs:
             echo "build_arch=false" >> $GITHUB_OUTPUT;
           fi
 
-      - name: Set up Docker Buildx
-        if: steps.check.outputs.build_arch == 'true' && env.BUILD_ARGS != '--test'
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to GitHub Container Registry
         if: env.BUILD_ARGS != '--test'
         uses: docker/login-action@v3


### PR DESCRIPTION
## Problem

Production builds on `main` branch are failing with the error:
```
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache.
Error response from daemon: No such image: ghcr.io/iangelov/addon-tailscale-amd64:v1.90.8
```

## Root Cause

The `home-assistant/builder@2025.09.0` action is **incompatible** with Docker Buildx when the `docker-container` driver is configured. Here's what happens:

1. **When Buildx is Active:**
   - Workflow sets up buildx with `docker/setup-buildx-action@v3`
   - This creates a `docker-container` driver instance
   - The builder action builds the image successfully
   - **BUT** it doesn't use `--push` or `--load` flags
   - Image remains in buildx cache only, not in local Docker daemon
   - Subsequent `docker tag` command fails: "No such image"

2. **Why Test Builds Worked:**
   - Previous fix skipped buildx setup when `BUILD_ARGS='--test'`
   - Used default docker driver instead
   - Images automatically loaded into local Docker daemon
   - Tagging worked fine

3. **Why Production Builds Failed:**
   - On push to `main`, `BUILD_ARGS` was cleared (set to empty string)
   - Buildx setup condition `env.BUILD_ARGS != '--test'` evaluated to TRUE
   - Buildx was configured, causing the incompatibility

## Solution

**Remove the Docker Buildx setup step entirely** from the workflow.

### Changes Made

- ❌ Removed `Set up Docker Buildx` step (lines 97-99)
- ✅ Kept `BUILD_ARGS` logic to differentiate test vs production
- ✅ Kept registry login for production builds
- ✅ Both test and production now use default docker driver

### Workflow Behavior After Fix

| Build Type | BUILD_ARGS | Docker Driver | Registry Push |
|------------|------------|---------------|---------------|
| Test (PR) | `--test` | default | ❌ No |
| Production (main) | `` (empty) | default | ✅ Yes |

## Testing

- [x] Fix applied and committed
- [ ] Wait for test build to complete on this PR
- [ ] Verify test build succeeds
- [ ] After merge, verify production build succeeds
- [ ] Confirm images are published to `ghcr.io/iangelov/addon-tailscale-{arch}`

## Trade-offs

**Lost Features:**
- Advanced buildx caching
- Native multi-platform support in single build
- Potential performance optimizations

**Gained Benefits:**
- ✅ Compatibility with home-assistant/builder action
- ✅ Stable, predictable builds
- ✅ Same behavior for test and production
- ✅ No complex buildx configuration needed

## Technical Details

The home-assistant/builder action appears to have been designed for use **without** external buildx configuration. When buildx is pre-configured with the docker-container driver, the action doesn't adapt its behavior to use the appropriate output flags (`--load` for local daemon or `--push` for registry).

This is a known limitation of mixing buildx docker-container driver with traditional Docker workflows that expect images to be in the local daemon.

## Related Issues

- Previous PR #35: Initially added buildx, which worked in test mode but failed in production
- Workflow run 19597865748: Failed production build that prompted this fix

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
