### PR TITLE
Add container image cleanup to builder workflow

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -53,3 +53,29 @@ jobs:
             --image "$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" \
             --docker-hub "ghcr.io/${{ github.repository_owner }}" \
             --addon
+
+  cleanup:
+    runs-on: ubuntu-24.04
+    name: Clean up old container images
+    needs: build
+    if: github.event_name == 'push'
+    strategy:
+      matrix:
+        arch: ["aarch64", "amd64"]
+    permissions:
+      packages: write
+
+    steps:
+      - name: Delete untagged images
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: addon-tailscale-${{ matrix.arch }}
+          package-type: container
+          delete-only-untagged-versions: true
+
+      - name: Keep only 5 most recent tagged versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: addon-tailscale-${{ matrix.arch }}
+          package-type: container
+          min-versions-to-keep: 5


### PR DESCRIPTION
## Summary
- Add cleanup job that runs after successful builds on push to main
- Delete untagged container images created during builds
- Retain only the 5 most recent tagged versions per architecture (aarch64, amd64)

## Test plan
- [x] Verify workflow YAML syntax is valid
- [x] Confirm cleanup job only runs on push events (not PRs)
- [x] Check that cleanup runs after build job completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)