### PR TITLE
Revert Tailscale version to v1.92.1

### DIFF
--- a/tailscale/build.yaml
+++ b/tailscale/build.yaml
@@ -2,4 +2,4 @@ build_from:
   aarch64: ghcr.io/hassio-addons/base/aarch64:19.0.0
   amd64: ghcr.io/hassio-addons/base/amd64:19.0.0
 args:
-  TAILSCALE_VERSION: "v1.92.2"
+  TAILSCALE_VERSION: "v1.92.1"

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -1,5 +1,5 @@
 name: Tailscale
-version: "v1.92.2"
+version: "v1.92.1"
 slug: tailscale-ha
 description: "A zero config VPN"
 url: "https://github.com/iangelov/home-assistant-addons/tree/main/tailscale"


### PR DESCRIPTION
## Summary
- Reverts Tailscale version from v1.92.2 to v1.92.1
- v1.92.2 is not yet available for Linux on pkgs.tailscale.com

## Context
PR #41 updated Tailscale to v1.92.2, but this version hasn't been released for Linux yet. The build will fail when trying to download the non-existent package.

## Changes
- `tailscale/build.yaml`: `TAILSCALE_VERSION: "v1.92.1"`
- `tailscale/config.yaml`: `version: "v1.92.1"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)