### PR TITLE
Fix cleanup deleting required untagged manifests

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -114,6 +114,7 @@ jobs:
           package-name: ${{ matrix.arch }}-app-tailscale
           package-type: container
           delete-only-untagged-versions: true
+          min-versions-to-keep: 10
 
       - name: Keep only 5 most recent tagged versions
         uses: actions/delete-package-versions@v5


### PR DESCRIPTION
## Summary

- The GHCR cleanup job's "delete untagged images" step was deleting platform manifests and attestation manifests that are children of tagged OCI image indexes created by `--attest type=provenance`
- This left tagged manifest lists pointing to non-existent digests, causing HA supervisor to fail with "manifest unknown" when pulling
- Add `min-versions-to-keep: 10` to preserve untagged children (platform manifest + attestation) of the 5 most recent tagged builds


🤖 Generated with [Claude Code](https://claude.com/claude-code)