### PR TITLE
tailscale: harden run.sh and install.sh

### DIFF
--- a/tailscale/files/install.sh
+++ b/tailscale/files/install.sh
@@ -13,10 +13,14 @@ case "$BUILD_ARCH" in
   "amd64")
     TAILSCALE_ARCH="amd64"
     ;;
+  *)
+    echo "Unsupported architecture: ${BUILD_ARCH}" >&2
+    exit 1
+    ;;
 esac
 
 echo "Downloading Tailscale ${TAILSCALE_VERSION} for ${BUILD_ARCH}..."
 
-curl -Ss "https://pkgs.tailscale.com/stable/tailscale_${TAILSCALE_VERSION}_${TAILSCALE_ARCH}.tgz" -o - | tar zxf -
+curl -fsSL "https://pkgs.tailscale.com/stable/tailscale_${TAILSCALE_VERSION}_${TAILSCALE_ARCH}.tgz" -o - | tar zxf -
 mv "tailscale_${TAILSCALE_VERSION}_${TAILSCALE_ARCH}/tailscale"* /bin/
 rm -rf "tailscale_${TAILSCALE_VERSION}_${TAILSCALE_ARCH}"

--- a/tailscale/run.sh
+++ b/tailscale/run.sh
@@ -6,47 +6,37 @@ set -Eeum -o pipefail
 TAILSCALE_SOCKET="/var/run/tailscale/tailscaled.sock"
 TAILSCALE_FLAGS=()
 TAILSCALE_SET_FLAGS=()
-TAILSCALED_FLAGS=("--statedir" "/data" "--state" "/data/tailscaled.state" "--socket" "${TAILSCALE_SOCKET}")
+TAILSCALED_FLAGS=("--statedir" "/data" "--socket" "${TAILSCALE_SOCKET}")
 PROXY_SERVE_HA=false
 
-if bashio::config.has_value 'advertise_exit_node'; then
-  if bashio::config.true 'advertise_exit_node'; then
-    TAILSCALE_FLAGS+=("--advertise-exit-node")
-  fi
+if bashio::config.true 'advertise_exit_node'; then
+  TAILSCALE_FLAGS+=("--advertise-exit-node")
 fi
 
-if bashio::config.has_value 'advertise_connector'; then
-  if bashio::config.true 'advertise_connector'; then
-    TAILSCALE_FLAGS+=("--advertise-connector")
-  fi
+if bashio::config.true 'advertise_connector'; then
+  TAILSCALE_FLAGS+=("--advertise-connector")
 fi
 
 if bashio::config.has_value 'advertised_routes'; then
-  routes=""
-  for route in $(bashio::config 'advertised_routes'); do
-    routes+="${route},"
-  done
-   # shellcheck disable=SC2001
-  TAILSCALE_FLAGS+=('--advertise-routes' "$(echo "$routes" | sed 's/,\s*$//')")
+  routes=$(bashio::config 'advertised_routes' | tr '\n' ',' | sed 's/,$//')
+  TAILSCALE_FLAGS+=('--advertise-routes' "$routes")
 fi
 
 if bashio::config.has_value 'tags'; then
-  tags=""
-  for tag in $(bashio::config 'tags'); do
-    tags+="${tag},"
-  done
-   # shellcheck disable=SC2001
-  TAILSCALE_FLAGS+=('--advertise-tags' "$(echo "$tags" | sed 's/,\s*$//')")
+  tags=$(bashio::config 'tags' | tr '\n' ',' | sed 's/,$//')
+  TAILSCALE_FLAGS+=('--advertise-tags' "$tags")
 fi
 
 if bashio::config.has_value 'auth_key'; then
-  TAILSCALE_FLAGS+=('--authkey' "$(bashio::config 'auth_key')")
+  # Pass the auth key via a file so it never appears in /proc/<pid>/cmdline.
+  AUTH_KEY_FILE=$(mktemp)
+  trap 'rm -f "$AUTH_KEY_FILE"' EXIT
+  printf '%s' "$(bashio::config 'auth_key')" > "$AUTH_KEY_FILE"
+  TAILSCALE_FLAGS+=('--authkey' "file:${AUTH_KEY_FILE}")
 fi
 
-if bashio::config.has_value 'force_reauth'; then
-  if bashio::config.true 'force_reauth'; then
-    TAILSCALE_FLAGS+=('--force-reauth')
-  fi
+if bashio::config.true 'force_reauth'; then
+  TAILSCALE_FLAGS+=('--force-reauth')
 fi
 
 if bashio::config.has_value 'hostname'; then
@@ -57,38 +47,37 @@ if bashio::config.has_value 'port'; then
   TAILSCALE_FLAGS+=('--port' "$(bashio::config 'port')")
 fi
 
-if bashio::config.has_value 'proxy_serve_ha'; then
-  if bashio::config.true 'proxy_serve_ha'; then
-    PROXY_SERVE_HA=true
-  fi
+if bashio::config.true 'proxy_serve_ha'; then
+  PROXY_SERVE_HA=true
 fi
 
-if bashio::config.has_value 'webclient'; then
-  if bashio::config.true 'webclient'; then
-    TAILSCALE_SET_FLAGS+=('--webclient=true')
-  fi
+if bashio::config.true 'webclient'; then
+  TAILSCALE_SET_FLAGS+=('--webclient=true')
 fi
 
 tailscaled -cleanup "${TAILSCALED_FLAGS[@]}"
 tailscaled "${TAILSCALED_FLAGS[@]}" &
 
 i=0
-while test $i -lt 12; do
-  if test -e "$TAILSCALE_SOCKET"; then
+while [[ $i -lt 12 ]]; do
+  if [[ -e "$TAILSCALE_SOCKET" ]]; then
     # bring up the tunnel
     tailscale --socket "$TAILSCALE_SOCKET" up --reset "${TAILSCALE_FLAGS[@]}"
 
-    if [ "${#TAILSCALE_SET_FLAGS[@]}" -gt 0 ]; then
+    if [[ ${#TAILSCALE_SET_FLAGS[@]} -gt 0 ]]; then
       tailscale set "${TAILSCALE_SET_FLAGS[@]}"
     fi
 
-    if [ "$PROXY_SERVE_HA" = true ]; then
+    if [[ "$PROXY_SERVE_HA" == true ]]; then
       tailscale serve --bg --https 443 http://localhost:8123
+    else
+      # Clear any serve config left over from a previous run with proxy_serve_ha=true.
+      tailscale serve reset 2>/dev/null || true
     fi
 
     # put Tailscale in foreground
     fg
-    exit $?
+    exit
   else
     (( i+=1 ))
     echo "tailscaled hasn't started yet, sleeping for 5 seconds..."


### PR DESCRIPTION
## Summary

- **run.sh**: stop leaking the Tailscale auth key via the command line — write it to a temp file (cleaned up on EXIT) and use `--authkey file:`, so the secret no longer appears in `/proc/<pid>/cmdline`.
- **run.sh**: clear stale `tailscale serve` config when `proxy_serve_ha` is toggled off — serve config persists in tailscaled state across restarts, so the previous behavior left the HTTPS proxy running indefinitely.
- **install.sh**: use `curl -fsSL` so HTTP 4xx/5xx fails the build with a real error instead of piping HTML into `tar`, and add a default `case` arm so an unsupported `BUILD_ARCH` fails with a clear message instead of `set -u` tripping on an unbound `TAILSCALE_ARCH` further down.
- Cleanup: drop the redundant `--state` (covered by `--statedir`), collapse `has_value` + `.true` doubled guards into a single `.true` call, simplify route/tag list construction with `tr '\n' ','`, normalize tests to `[[ ]]`, replace `exit $?` after `fg` with bare `exit`.

Out of scope (called out separately, not addressed here): adding SHA256 verification of the downloaded Tailscale archive in `install.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)